### PR TITLE
Option normalem hinzu

### DIFF
--- a/slides/ansible-workshop.ltx
+++ b/slides/ansible-workshop.ltx
@@ -11,7 +11,7 @@
 \usepackage{listings}
 \lstset{basicstyle=\footnotesize\ttfamily,breaklines=true}
 \usepackage{tikz}
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 \usetikzlibrary{trees}
 
 


### PR DESCRIPTION
Die Option `normalem` sorgt dafür, dass \emph sich nomal verhält.